### PR TITLE
Contributorconduct

### DIFF
--- a/content/about/05_conduct.md
+++ b/content/about/05_conduct.md
@@ -11,18 +11,15 @@ status: experimental
 version: "0.3 (2022-03-07)"
 ---
 
-# Code of Conduct
-
 ## Our Commitment 
 
 We are learning in the open with the RAD Housing project. This includes sharing our documentation and hosting spaces to explore the concepts and practices of retrofitting and decommodifying housing while living more collectively and acting in solidarity with broader movements for justice. We welcome friendly contributions and expect each other to participate in ways that align with our conduct expectations.
 
 As contributors, we agree:
-
-    To act in alignment with our Conduct Expectations (outlined below)
-    To act and interact in ways that contribute to an open and welcoming experience for all participants.
-    To practice supporting each other to conduct ourselves in ways that align with these expectations.
-    To support project leaders to respond to situations where conduct expectations are not met by following our Response Guidelines (outlined below)
+- To act in alignment with our Conduct Expectations (outlined below)
+- To act and interact in ways that contribute to an open and welcoming experience for all participants.
+- To practice supporting each other to conduct ourselves in ways that align with these expectations.
+- To support project leaders to respond to situations where conduct expectations are not met by following our Response Guidelines (outlined below)
     
 
 ## Our Expectations
@@ -72,8 +69,9 @@ decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all spaces hosted by project leaders, and also applies when
-an individual is representing the project in public spaces. Examples of representing our project include acting as an appointed representative via email, on social media, or at an online or offline event.
+This Code of Conduct applies within all spaces hosted by project leaders, and also applies when an individual is representing the project in public spaces. Examples of representing our project include acting as an appointed representative via email, on social media, or at an online or offline event.
+
+Any projects implementing RAD Housing approaches are expected to take responsibility for developing and maintaining their own conduct agreements. For an example, see the [Brassica Collective Conduct Agreement](/brassica/handbook/agreements/conduct_agreement/)
 
 ## Response Guidelines
 

--- a/content/about/05_conduct.md
+++ b/content/about/05_conduct.md
@@ -1,0 +1,124 @@
+---
+title: Contributor Code of Conduct
+prev: solidarity
+next: /t2s-model
+type: docs
+slug: conduct
+weight: 5
+sidebar:
+open: true
+status: experimental
+version: "0.3 (2022-03-07)"
+---
+
+# Code of Conduct
+
+## Our Commitment 
+
+We are learning in the open with the RAD Housing project. This includes sharing our documentation and hosting spaces to explore the concepts and practices of retrofitting and decommodifying housing while living more collectively and acting in solidarity with broader movements for justice. We welcome friendly contributions and expect each other to participate in ways that align with our conduct expectations.
+
+As contributors, we agree:
+
+    To act in alignment with our Conduct Expectations (outlined below)
+    To act and interact in ways that contribute to an open and welcoming experience for all participants.
+    To practice supporting each other to conduct ourselves in ways that align with these expectations.
+    To support project leaders to respond to situations where conduct expectations are not met by following our Response Guidelines (outlined below)
+    
+
+## Our Expectations
+
+We as contributors we commit to make participation in this event a harassment-free experience for everyone, regardless of gender, race, class, age, ability and any other social category. We believe that all of our freedoms are tied up together, and we cannot leave each other behind in our fight for justice. 
+
+Examples of behaviors that contributes to a positive environment for contributors include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Practising relating-well across differences 
+* Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+* Asking for consent prior to initiating physical contact or other personal interactions, and accepting “no” immediately.
+* Focusing on what is best not just for us as individuals, but for our broader communities 
+* Respecting the leadership of those who are most impacted by an issue, while avoiding deferential or extractive expectations of their time/energy
+* Learning about and unlearning our default assumptions and unconscious biases
+* Co-creating opportunities for people to change oppressive behaviours
+* Leveraging our collective resources to support political engagement and participate in broader solidarity movements.
+
+Examples of unacceptable behaviour include:
+
+* Any form of discrimination, the use of slurs or other harmful language, microaggressions, minimisation or sidelining of forms of oppression (e.g., suggestions that we don’t have time to talk about racism, ableism, etc)
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Pressuring, shaming, or coercing anyone to drink or use drugs
+* Filming/photographing anyone without explicit consent
+* The use of sexualized language or imagery, and sexual attention or advances of any kind without clear, enthusiastic, specific, and ongoing consent, or toward anyone unable to consent.
+* Consistently speaking on behalf of communities you’re not part of, or taking actions against the advice or wishes of impacted communities or otherwise disrespecting or minimising their feedback
+* Proposing punitive responses, such as demanding punishments, calling the cops, or refusing to provide opportunities for others to change their behaviours.  
+* Other conduct which could reasonably be considered inappropriate in a public setting
+
+## Enforcement Responsibilities
+
+Project leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Project leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all spaces hosted by project leaders, and also applies when
+an individual is representing the project in public spaces. Examples of representing our project include acting as an appointed representative via email, on social media, or at an online or offline event.
+
+## Response Guidelines
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at crew@radhousing.org
+All complaints will be reviewed and investigated promptly and fairly.
+
+All project leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Responsibilities
+
+Project leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Check-in / Reminder
+
+**Impact**: Minor uses of inappropriate language or other behavior deemed inappropriate or unwelcome in project spaces.
+
+**Consequence**: A friendly check-in or reminder from project leaders, clarifying the issue and the expected change.
+
+### 2. Warning
+
+**Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behaviors. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Seperation
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary separation (e.g., step outside or move to a chill-out space) with support from an organiser/buddy from any sort of interaction or public communication with the within the project spaces for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban. 
+
+### 4. Removal from Project Spaces
+
+**Community Impact**: Demonstrating a pattern of violation of our contributor standards, including sustained inappropriate behaviors, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**:
+Removal from project spaces indefinitely. Project organisers will also review of the conditions that led to the exit, and will work with affected parties to identify any broader changes we may need to initiate within our project spaces.
+
+Police will not be called except in circumstances where all community-based options have been exhausted and there is an immediate threat to life. We recognise police presence often escalates harm, especially for marginalised people.
+
+### 5. Re-entry pathways: 
+We believe that people are capable of change and self reflection in their own time. A re-entry pathway may be considered if a person who has been removed from project spaces has demonstrated long term extensive change in behaviour. 
+
+## Attribution
+
+This Code of Conduct is adapted from the [Common Guide Code of Conduct for Grassroots Ecosystems](https://demo.common.guide/groupings/grassroots-ecosystem/code-of-conduct/)


### PR DESCRIPTION
Add a contributor code of conduct for those contributing to RAD Housing projects, including at RAD Housing events