### PR TITLE
add buddies guidelines and update navigation in how-to section

### DIFF
--- a/content/brassica/handbook/Agreements/conduct_agreement.md
+++ b/content/brassica/handbook/Agreements/conduct_agreement.md
@@ -10,12 +10,12 @@ sidebar:
 ---
 
 This document forms part of our broader set of emerging Participation Agreements, and outlines how we currently understand our:
-* expectations of how we conduct ourselves while involved in the project, including while on hiatus from participation responsibilities
+* expectations of how we conduct ourselves while involved in the project in any way, including while on hiatus from participation responsibilities and while involved as a collaborator
 * gradually escalating processes for responding to each other in situations where our conduct does not align with our collective agreements
 * approach to supporting each other to hold ourselves accountable for how our actions impact each other as we learn and change together
 
 ## Conduct Agreement
-As participants and collaborators, we agree:
+While involved in the Brassica Collective, we agree:
 * To act in alignment with our **Conduct Expectations** (as detailed below)
 * To act in alignment with any conduct expectations expressed in our other agreements
 * To take responsibility for holding ourselves and others accountable for conduct that does not align with our shared expectations by acting in accordance with the **Response Guidelines** (detailed below).
@@ -68,12 +68,12 @@ We believe that all of our freedom is tied up together, and we cannot leave each
 
 ## Conduct Supporters
 
-In the following guidelines, 'conduct supporter(s)' indicate those participants who are acting in the relevant conduct supporter role(s) e.g. accountability support or care support. These roles, and how they differ from the ‘participation buddies’ role are expected to be clarified by a [Conduct Supporters Agreement](/content/brassica/handbook/Agreements) and [participation buddies guidlines](/content/brassica/handbook/Howtos); if no such agreement and guidelines exist then we expect to implement a single ‘care supporter’ role with the following set of responsibilities:
+In the following guidelines, 'conduct supporter(s)' indicate those participants who are acting in the relevant conduct supporter role(s). These roles, and how they differ from ‘participation buddies’ are expected to be clarified by a Conduct Supporters Agreement. 
 
-- Responding to requests by other participants for care following situations in which supportees felt (or contributed to others feeling) misunderstood, participated in or witnessed a conflict, and/or experienced harm.
-- Responding to requests by other participants to help those who want to hold themselves accountable for their role in mistakes, misunderstandings, conflict, and/or harmful situations.
+If the Conduct Supporters Agreement has not been implemented, then each participant’s respective ‘buddy’ (or the participant who invited the collaborator) takes responsibility for responding to requests from participants or collaborators for support to initiate and/or participate in one of our conduct agreement responses, including: 
+* Responding to requests by other participants for care following situations in which supportees felt (or contributed to others feeling) misunderstood, participated in or witnessed a conflict, and/or experienced harm.
+* Responding to requests by other participants to help those who want to hold themselves accountable for their role in mistakes, misunderstandings, conflict, and/or harmful situations. 
 
-Each interval, participants can opt into this role. If no participants opt into this role, the associated responsibilities will be transferred to each participant’s respective participation buddy.
 
 ## Response Guidelines
 Drawing on lessons from [transformative justice movements](https://commonslibrary.org/transformative-approaches-to-conflict-resolution/), these responses include actions that we are individually responsible for (e.g., approaching misunderstandings with curiosity), as well as actions we take responsibility for as a collective (e.g., paying for and participating in cultural awareness training).

--- a/content/brassica/handbook/Howtos/buddies_guidelines.md
+++ b/content/brassica/handbook/Howtos/buddies_guidelines.md
@@ -1,0 +1,78 @@
+---
+title: Guidelines for Participation Buddies
+slug: guidelines_buddies
+type: docs
+prev: guidelines_collaborators
+next: handbook_editing
+weight: 5
+sidebar:
+open: true
+---
+
+### Participation Buddies  
+Participation Buddies support *each-other* to communicate and meet our participation intentions in the project.
+
+Each interval, participants are paired into ‘Participation Buddies’ unless they explicitly opt-out. 
+
+What types of support buddies agree to will vary depending on the participant pairs. Examples include:
+
+* Checking in on well-being and capacity during the interval   
+* Building 1:1 communication and relational practices (e.g. direct messaging, meeting up, sharing activities)  
+* Discussing upcoming proposals and offering reminders to contribute to decision-making processes  
+* Discussing current discussion topics and encouraging each other to share and record ideas and thoughts that come up (e.g. by adding comments to a thread on Loomio)  
+* Decision-support for opting-in or \-out of each type of participation prior to the following interval
+* Responding to requests to initiate and/or participate in conduct agreement response processes, if their Conduct Supporters are unavailable
+
+### Distributing Participation Support 
+
+Participation Buddies as a form of mutual support is  currently **distributed** via an algorithm that randomly pairs all active (not on hiatus)  participants who have not opted-out of participation buddies. 
+
+The allocation of buddies is distributed to help us build relationships between participants (more evenly than we might otherwise) and collectively take responsibility for moving the project forward. 
+
+### Review Conditions
+
+These guidelines  will be reviewed in any of the following circumstances: 
+
+* When an agreement is amended in ways that impact the implementation of these guidelines  
+* When an amendment is proposed to these guidelines
+
+### Supplementary Materials 
+
+#### Context Questions & Assumptions 
+
+##### *Is this document (or any of our guidelines) perfect and set in stone?*
+
+* Absolutely not. As with our other guidelines, we expect this document to be changed as we try, fail, learn, and review our shared expectations of how to navigate the ever-changing dynamics of our collective. 
+
+##### *Where can I find more information about the jargon terms and associated assumptions in these guidelines?* 
+
+* The ‘collective’ referenced in these guidelines is the Brassica Collective, as described in our [handbook](https://radhousing.org/brassica/handbook/)   
+* These guidelines assume familiarity with our broader set of [collective agreements](https://radhousing.org/brassica/handbook/agreements/) and any ambiguities should be interpreted in that context. In this context:   
+  * A ‘current participant’ is described in the [Responsibilities and Expectations Agreement](../../agreements/responsibilities_and_expectations).  
+* For any unfamiliar terminology not adequately explained in our glossary of terms, please ask for help to update our glossary and/or propose an amendment to this agreement as appropriate.  
+
+##### Why do we need Participation Buddies Guidelines?
+
+* Like our Conduct Supporter roles, the  Participation Buddy role helps us practice distributing the support responsibilities we share throughout our web of relationships so that the care work does not just fall to those who have been socialised to feel responsible for it.  
+* By rotating supporter roles we can practice building relationships with participants we might not otherwise have approached within the collective.
+
+##### What is the scope of Participation Buddies support responsibilities? 
+
+* In our role as Participation Buddies we can expect to support each other to review and  implement our set of Participation Agreements \- in particular our Responsibilities and Expectations agreement.   
+* For example, in our role as Participation Buddies we may reflect on how intentionally we are opting-in and \-out of the responsibilities and expectations of participating in this project.  
+* Participants are encouraged to reach out to their broader support networks for support requests that are unrelated to participation in the collective housing project (noting that at times this may include individuals who are also participants in the collective where those individuals have agreed to support each other outside the context of involvement in the same housing collective).
+
+##### Why has our previous Participation Buddies approach been formalised as a set of Guidelines? 
+
+* These guidelines build on our experimental implementation of a ‘buddy system’ practice where active participants were randomly paired each interval. The initial expectation of buddies was ‘to connect once during the interval to support each other to participate in collective decisions’. This informal form of paired mutual support was practised prior to and during the process of creating our set of Participation Agreements. When we came to writing up our Conduct Supporter agreement (which describes two main Conduct Supporter roles) it became clear there was a need to formally define the Participation Buddies supporter role in order to avoid confusion.  
+* For more information on the Conduct Supporter roles see the Conduct Supporter agreement.
+
+##### Why aren’t any other types of supporter roles included in these guidelines?
+
+* Participation Buddy is a *mutual support* role which is a formalisation of an existing form of support that we hope will continue as we implement our Conduct Supporter roles.  
+* Participants can propose an amendment to these guidelines to add additional mutual support roles that become relevant within the context of our collective capacity to support each other.
+
+##### Why doesn’t this agreement consider all possible scenarios we might face as a collective? 
+
+* We expect this agreement to be updated as we try, fail, learn, and review our shared expectations of how to navigate the ever-changing dynamics of our collective.   
+  

--- a/content/brassica/handbook/Howtos/collaborator_guidelines.md
+++ b/content/brassica/handbook/Howtos/collaborator_guidelines.md
@@ -3,7 +3,7 @@ title: Guidelines for Collaborators
 slug: guidelines_collaborators
 type: docs
 prev: guidelines_non-participant
-next: handbook_editing
+next: guidelines_buddies
 weight: 4
 sidebar:
 open: true

--- a/content/brassica/handbook/Howtos/handbook_editing.md
+++ b/content/brassica/handbook/Howtos/handbook_editing.md
@@ -2,9 +2,9 @@
 title: Handbook Editing
 slug: handbook_editing
 type: docs
-prev: guidelines_collaborators
+prev: guidelines_buddies
 next: handbook
-weight: 5
+weight: 6
 sidebar:
   open: true
 ---


### PR DESCRIPTION
Nothing special here; just adding the guidelines as has been on the backlog for a while. 