### PR TITLE
fix links on landing page

### DIFF
--- a/content/brassica/_index.md
+++ b/content/brassica/_index.md
@@ -11,6 +11,7 @@ This is a landing page for participants in the collective to find all the resour
 
 {{< cards >}}
 {{< card link="/brassica/handbook" title="Brassica Handbook" icon="book-open" >}}
-{{< card link="about" title="About RAD Housing" icon="question-mark-circle" subtitle="What does it mean to retrofit and decommodify housing?" >}}
-{{< card link="t2s-model" title="T2S Model" icon="document-text" subtitle="The Transition to Stewardship model is a legal/financial approach to transition housing away from being a financial commodity" >}}
+{{< card link="/about/" title="About RAD Housing" icon="question-mark-circle" subtitle="What does it mean to retrofit and decommodify housing?" >}}
+{{< card link="/t2s-model/" title="T2S Model" icon="document-text" subtitle="The Transition to Stewardship model is a legal/financial approach to transition housing away from being a financial commodity" >}}
 {{< /cards >}}
+

--- a/content/brassica/handbook/Agreements/conduct_agreement.md
+++ b/content/brassica/handbook/Agreements/conduct_agreement.md
@@ -190,7 +190,7 @@ Continued learning: The group will work to assess the conditions that led to the
 Re-entry pathways: In keeping with abolitionist views that people are capable of change and self reflection in their own time, a re-entry pathway may be considered if the person shows long term extensive change in behaviour and expresses interest in participating again. In circumstances where participants remain concerned about safety, collective-wide decisions may need to be made about how we determine our capacity for responding to these concerns.
 
 ## Review Conditions
-This agreement will be reviewed in any of the following circumstances (whichever comes first):
+This agreement (Version 5.1) will be reviewed in any of the following circumstances (whichever comes first):
 * Whenever a participant proposes an amendment to this agreement
 * When any agreement in the set of Participation Agreements is amended
 * Prior to the first participants living in a collectively stewarded site

--- a/content/brassica/handbook/Agreements/entry_and_exit_pathways.md
+++ b/content/brassica/handbook/Agreements/entry_and_exit_pathways.md
@@ -19,7 +19,9 @@ This document forms part of our set of emerging Participation Agreements, and ou
 ## Entry Pathway {#entry-pathway}
 ### Expression of Interest {#expression-of-interest}
 
-When a person expresses an interest in participating in the collective, it is expected to include:
+Expressions of interest specify intentions to contribute to the project as a Collaborator and/or as a Participant
+
+When a person expresses an interest in contributing to the collective, it is expected to include:
 
 1. A description of their current understanding of the foundational (RAD housing) context for the Brassica Collective
 2. A commitment to acting in alignment with the current agreements and processes the collective has shared publicly while contributing to co-creating emerging collective practices going forward.

--- a/content/brassica/handbook/Agreements/entry_and_exit_pathways.md
+++ b/content/brassica/handbook/Agreements/entry_and_exit_pathways.md
@@ -171,6 +171,7 @@ When a participant opts-out indefinitely or is otherwise indefinitely absent, PA
 1. Removing the exiting participant’s access to the collective's communication channels
 2. Reminding the exiting participant that they are relinquishing their expectations of the collective (including expectations of housing security, if relevant).
 3. Returning the exiting participant’s transitional equity (following the *withdrawal of equity* process detailed in the Transition to Stewardship model).
+4. Adding the exiting participant to our pool of collaborators (unless requested otherwise) to enable them to stay involved in the project in ad-hoc ways, and to more easily express interest in participating again in the future.
 
 ## Review conditions {#review-conditions}
 
@@ -205,3 +206,6 @@ _Why doesn’t this agreement consider all possible scenarios we might face as a
 
 * We also expect this agreement to be updated as we try, fail, learn, and review our shared expectations of how to navigate the ever-changing dynamics of our collective.
 
+_Why do we add exiting participants as Collaborators (unless requested otherwise)?_ 
+
+* Encouraging collaboration is intended to make it easier to for participants to take a rest from their responsibilities with the knowledge they can express interest in participating again in the future.

--- a/content/brassica/handbook/Agreements/multi_site_purchasing.md
+++ b/content/brassica/handbook/Agreements/multi_site_purchasing.md
@@ -96,7 +96,7 @@ The following general principles guide the development of our specific purchase 
 
 ## Review Conditions
 
-This agreement will be reviewed in any of the following conditions (whichever comes first): 
+This agreement (Version 1.1) will be reviewed in any of the following conditions (whichever comes first): 
 
 -   The collective agrees on a clear vision or mission statement
 -   The collective passes an agreement describing house theming, or who gets to live in each house.

--- a/content/brassica/handbook/Agreements/responsibilities_and_expectations.md
+++ b/content/brassica/handbook/Agreements/responsibilities_and_expectations.md
@@ -71,7 +71,7 @@ Acknowledging that the collective does not yet have any site-specific agreements
 3. The assurance that, once residing in an established house stewarded by the collective, I can stay as long as I meet all relevant responsibilities as a resident of that house and to the broader collective
 
 ## Review Conditions
-This agreement (*Version: 4.2*) will be reviewed in any of the following conditions:
+This agreement (*Version: 5*) will be reviewed in any of the following conditions:
 1. Whenever a participant proposes an amendment to this agreement
 2. When any agreement in the set of Participation Agreements is amended
 3. Prior to the first participants living in a collectively stewarded site

--- a/content/brassica/handbook/Howtos/buddies_guidelines.md
+++ b/content/brassica/handbook/Howtos/buddies_guidelines.md
@@ -31,7 +31,7 @@ The allocation of buddies is distributed to help us build relationships between 
 
 ### Review Conditions
 
-These guidelines  will be reviewed in any of the following circumstances: 
+These guidelines (Version 2) will be reviewed in any of the following circumstances: 
 
 * When an agreement is amended in ways that impact the implementation of these guidelines  
 * When an amendment is proposed to these guidelines


### PR DESCRIPTION
Not sure if the two links on the landing page broke or never worked, but they should work now... 
Also reconciled version details in draft docs and handbook