### PR TITLE
Guidelines for Conduct Supporter Roles

### DIFF
--- a/content/brassica/handbook/Howtos/buddies_guidelines.md
+++ b/content/brassica/handbook/Howtos/buddies_guidelines.md
@@ -3,7 +3,7 @@ title: Guidelines for Participation Buddies
 slug: buddies_guidelines
 type: docs
 prev: guidelines_collaborators
-next: handbook_editing
+next: guidelines_supporters
 weight: 5
 sidebar:
 open: true

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -15,22 +15,18 @@ The following guidelines outline our in-progress collection of tips & tools for 
 
 ## When and How to Request Support?
 
-Practising with small misunderstandings and disagreements that have low-consequences - like those we'd prefer to let-slide - can help prepare us for when we need to collectively navigate more serious high-consequence forms of conflict.
+Practising asking for support in low-consequence contexts, can help prepare us for when we need to support each other navigate high-consequence forms of conflict.
 
-For example, seeking out accountability support is encouraged whenever gap emerge between what we intend with our actions and the actual impacts on others in the context of participating in the collective. 
-
-By inviting feedback from others we can learn the skills of being able to give and receive feedback about how we are doing in relation to our own commitments. With practice, asking for feedback can become a regular part of how we operate together.
-
-Likewise, seeking care support is encouraged whenever feelings emerge in the context of participating in Brassica Collective. Asking for and holding a container to express strong feelings offers opportunities to practice integrating our experiences and reconnecting with people around us.
+Examples of some of the low-consequence contexts we can practice seeking support include: when we experience feelings about how others are participating in the collective; when we learn that the way we're participating in crews is impacts others in ways we did not intend; and when we have a minor disagreement we're unable to resolve directly with another participant.  
 
 #### Identifying when to talk who, about what 
-Both types of support will can be relevant for the same situations; each benefits from specific forms of interacting and recognising form is  most useful in relation to when we ge the other is part of what we're practising. 
+While both types of support will be relevant for most situations, recognising which form of support is most useful when is part of what we're practising. 
 
-* Care support offers a [holding space](https://psychhub.com/resources/articles/holding-space) for to express their feelings and perspectives without judgement or advice
+* Care support offers a [holding space](https://psychhub.com/resources/articles/holding-space) to practice expressing our feelings and reflecting on our experiences  without exposing ourselves to judgement or advice.
 
-* Accountability support offers a gentle challenge to reflect on alternative perspectives that help us practice holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
+* Accountability support offers a gentle challenge to practice reflecting on alternative perspectives and holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-The following diagram offers an example of the varied and iterative pathways between each of our Supporters this may involve: 
+The following diagram offers an example of the varied and iterative pathways we might seek out each of our Supporters for one instance of feeling misunderstood: 
 
 ```mermaid
 graph LR
@@ -41,12 +37,12 @@ C --> A
 A--> D[I feel ready to direcly resolve the misunderstanding]-->A
 ```
 
-#### Metacommunicate that want to Asking for, or Offer, Support:
+#### Ask for support:
 Once you know who you want to talk to about what:
-- Contact the person in the relevant Supporter role in relation to you   
-- Offer a brief overview of the scope and goal of your request 
-- Once the goal has been articulated and consented to, and all parties have indicated sufficient capacity, agree on the format of communication and any structured-discussion tools.
-- At an agreed time/place, take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) and check that everyone has the available time, energy, and mental-space to give the conversation the appropriate level of attention. If anyone does not have capacity, set another time to reconvene. 
+- Contact whoever is in the relevant Supporter role(s) in relation to you  
+- Offer a brief overview of the scope of your request and check if they are willing and able to offer support. 
+- Once the support request has been articulated and consented to, agree on the format of communication and any [structured-discussion tools](https://hackmd.io/@IntentionalRelationships/metacommunication).
+- At an agreed time/place, take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) and check that everyone has capacity to give the conversation the appropriate level of attention. If anyone does not have capacity, set another time to reconvene.
 
 ## When & How to Offer Support
 Your roles as a Conduct Supporter is to offer support on request, and in the context of navigating experiences within the Brassica Collective. 

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -13,42 +13,50 @@ open: true
 
 ***Conduct Supporter*** roles are intended to help us distribute the labour of meeting our shared conduct expectations when resolving misunderstandings, identifying and responding to conflicts, reducing the conditions within which we might harm each other, and practising how we respond to harm when it does occur. 
 
+## FAQs
 
-### Differentiating between Care Support and Accountability Support
+### Why differentiate between Care Support and Accountability Support?
 While supporting someone to hold themselves accountable is a form of care-work (broadly understood), it can be helpful to treat it as different from the care support, above because each requires a different form of interaction. 
-* Care support requires an active-listening form of support that focuses on listening to someone express their perspective and respecting the kinds of support requested (even when these may be different to the kinds of support we think they need or ‘should’ have). 
-* Accountability support requires a perspective-broadening form of support. It focuses on supporting someone to take responsibility for the consequences of their choices, acknowledge when these impact others, and learn to make choices that are more aligned with our conduct expectations and collectively agreed values (and less likely to harm others). 
+* Care support requires an holding-space forms of support that focus on listening to someone express their perspective and respecting the kinds of support requested (even when these may be different to the kinds of support we think they need or ‘should’ have). See this explanation of the care-work of ['holding space'](https://psychhub.com/resources/articles/holding-space) for people toe express their feelings and perspectives without judgement or advice.
+* Accountability support is about offering  self-reflective and perspective-broadening opportunities; not policing each others' behaviour. This type of support is useful when someone is ready to take responsibility for the consequences of their choices. In this context, the goal is to support each other learn how to hold ourselves accountable for what we said we would do (not to hold others accountable for what they said they would do), including learning about and acknowledging when our behaviour impacting others, and (where relevant)how to change behaviours to reduce potential for harming others. See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-## Care Support Guidelines
+### When do I request Care and/or Accountability?
 
-### Tips for holding space for participants to express their feelings and perspectives without judgement or advice. 
+Practising skills in low consequence conflict can prepare us for if/when we need to collectively navigate more serious instances of violence and/or abuse (i.e., [behaviours …intended to gain, exert, and maintain power over another person or in a group](https://commonslibrary.org/book-review-we-will-not-cancel-us/)).
+
+For example, seeking out accountability support is encouraged whenever gap emerge between what we intend with our actions and the actual impacts on others in the context of particiating in the collective. By inviting feedback from others we can learn the skills of being able to give and receive feedback about how we are doing in relation to our own commitments. With practice, asking for feedback can become a regular part of how we operate together.
+
+Likewise, seekng care support is encouraged whenever feelings emerge in the context of participating in Brassica Collective. Asking for and holding a container to express stong feelings... 
+
+## Tips & Tools for Asking for Support
+
+...
+
+## Tips & Tools for Providing Support
+
+### Providing Care Support
+
+**Tips for holding space for participants to express their feelings and perspectives without judgement or advice.** 
 * Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* (while avoiding forming judgements or offering advice)..  
 
-### Tips for responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm. 
+**Tips for responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
 * Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  
 
-### Tips for supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement
-- who has expressed feelings about actions within the collective that are at odds with our shared expectations or values.
-- Reminding participants to reach out to their Accountability Supporter for additional forms of conduct support.
+**Tips for supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement**
+- When someone has expressed feelings about actions within the collective that are at odds with our shared expectations or values, remind participants to reach out to their Accountability Supporter for additional forms of conduct support.
 
-### Additional Resources:
-A explanation of how to ['holding space'](https://psychhub.com/resources/articles/holding-space) for participants to express their feelings and perspectives without judgement or advice.  
-
-## Accountability Supporter Guidelines
-
-* A video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)   
+## Providing Accountability Supporter
 
 ### Tips for supporting people to consider alternative perspectives
-* 
 * Offer “yes, and” perspective on what else might be true with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advice)
 * Use the [ladder of inference framework] to support them to the role of assumptions, observations, conclusions, and actions in their interpretations .  
 * Offer examples of when/how actions aren’t aligning with our collectively agreed expectations.  
 * Provide a practice-partner to role-play different ways of interacting
+* Offer to facilitate a [Perspective-sharing process](https://hackmd.io/@Teq/perspective-sharing-facilitation)
 
-### Tips for having 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.  
+**Tips for having 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.** 
   
-### Tips for identify if/when someone is ready to hold themselves accountable for the consequences of their actions
-Signs that someone may be ready include demonstrating capacity for:
+**Signs that someone may be ready to hold themselves accountable for the consequences of their actions include:**
 - Recognising and sitting with uncomfortable feelings;
 - Identifying when/how actions aligned with values (or not)
 - Acknowledging when and how the relevant actions impacted others
@@ -57,17 +65,19 @@ Signs that someone may be ready include demonstrating capacity for:
 
 > *“People can support you to be accountable, but no one but you can do the hard work of taking accountability for yourself. Don’t wait until someone else has to bring up your behavior.” [(Mia Mingus)](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*
 
-### Tips for supporting people who want to hold themselves accountable for the ways their actions were felt by themselves or others to have contributed to misunderstandings, conflict, and/or harmful situations. 
+**Tips for supporting people who want to hold themselves accountable for the ways their actions were felt by themselves or others to have contributed to misunderstandings, conflict, and/or harmful situations** 
 - Support engagement in the relevant processes outlined in our other agreements    
 - Reminding participants to reach out to their Care Supporter for additional forms of conduct support.
 - Offer resources, such as:
     - [How to give a good apology](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
 
 
-### Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.
+**Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.**
 
 
 ## Further Resources 
+
+> "... I finally, finally, take a deep breath and ask for the care I need most from my friends, and am able to do this because of the collective work done to make accepting that care safe and possible." [Leah Lakshmi Piepzna-Samarasinha](https://amplifybookstore.com/products/the-future-is-disabled-by-leah-lakshmi-piepzna-samarasinha?variant=47864940691735) 
 
 The following resources focus on approaches to conflict that seek to transform oppressive dynamics, our relationships to each other, and our communities at large. 
 
@@ -77,5 +87,6 @@ The following resources focus on approaches to conflict that seek to transform o
 - [From conflict to co-operation - a Primer](https://peoplesupport.coop/from-conflict-to-cooperation/) - Written by Kate Whittle, Cooperantics, and illustrated by Angela Martin. This From Conflict to Co-operation series aims to help co-operatives not only to deal with conflict when it arises but also to avoid unnecessary conflict.
 - [Conflict Resolution Trainers Manual](https://www.crnhq.org/cr-trainer-manual/) This manual is a comprehensive guide running for highly successful Conflict Resolution sessions. It offers teaching material, group and individual exercises and handouts for over 50 hours of instruction on the 12 skills of Conflict Resolution. Each chapter starts with clear guidelines for constructing training sessions of different lengths. It is invaluable for a new trainer and will refresh and inspire even the most experienced trainer’s material. 
 - [Community Accountability process](https://callingupjustice.com/fumbling-towards-repair/)
+- [Upstream podcast episode Nov 7 2024 "Prefigurative Politics and Workplace Democracy w/Saio Gradin and Nicole Wires"](https://www.upstreampodcast.org/conversations) 
 
 

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -9,55 +9,73 @@ sidebar:
 open: true
 ---
 
-## Overview
+[**Conduct Supporter roles**](../../agreements/supporter_agreement) are intended to help us distribute the labour of supporting each other to act in alignment with our [Conduct Agreement](../../agreements/conduct_agreement). 
 
-***Conduct Supporter*** roles are intended to help us distribute the labour of meeting our shared conduct expectations when resolving misunderstandings, identifying and responding to conflicts, reducing the conditions within which we might harm each other, and practising how we respond to harm when it does occur. 
+The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to offer when we're asked for each of these specific forms of conduct support.
 
-**Why differentiate between Care Support and Accountability Support?**
-While supporting someone to hold themselves accountable is a form of care-work (broadly understood), it can be helpful to treat it as different from the care support, above because each requires a different form of interaction. 
-* Care support requires an holding-space forms of support that focus on listening to someone express their perspective and respecting the kinds of support requested (even when these may be different to the kinds of support we think they need or ‘should’ have). See this explanation of the care-work of ['holding space'](https://psychhub.com/resources/articles/holding-space) for people toe express their feelings and perspectives without judgement or advice.
-* Accountability support is about offering  self-reflective and perspective-broadening opportunities; not policing each others' behaviour. This type of support is useful when someone is ready to take responsibility for the consequences of their choices. In this context, the goal is to support each other learn how to hold ourselves accountable for what we said we would do (not to hold others accountable for what they said they would do), including learning about and acknowledging when our behaviour impacting others, and (where relevant)how to change behaviours to reduce potential for harming others. See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
+## When and How to Request Support?
 
-## When Do We Request Support?
+Practising with small misunderstandings and disagreements that have low-consequences - like those we'd prefer to let-slide - can help prepare us for when we need to collectively navigate more serious high-consequence forms of conflict.
 
-Practising skills in low consequence conflict can prepare us for if/when we need to collectively navigate more serious instances of violence and/or abuse (i.e., [behaviours …intended to gain, exert, and maintain power over another person or in a group](https://commonslibrary.org/book-review-we-will-not-cancel-us/)).
+For example, seeking out accountability support is encouraged whenever gap emerge between what we intend with our actions and the actual impacts on others in the context of participating in the collective. 
 
-For example, seeking out accountability support is encouraged whenever gap emerge between what we intend with our actions and the actual impacts on others in the context of particiating in the collective. By inviting feedback from others we can learn the skills of being able to give and receive feedback about how we are doing in relation to our own commitments. With practice, asking for feedback can become a regular part of how we operate together.
+By inviting feedback from others we can learn the skills of being able to give and receive feedback about how we are doing in relation to our own commitments. With practice, asking for feedback can become a regular part of how we operate together.
 
-Likewise, seekng care support is encouraged whenever feelings emerge in the context of participating in Brassica Collective. Asking for and holding a container to express stong feelings offers oppourtunities to practive integrating our experiences and reconnecting with people around us.
+Likewise, seeking care support is encouraged whenever feelings emerge in the context of participating in Brassica Collective. Asking for and holding a container to express strong feelings offers opportunities to practice integrating our experiences and reconnecting with people around us.
 
-Typically, both types of support will be relevant to any situation. However, recognising when/why each specific type of support is most relevant is part of what we're hoping to learn through these practices.  
+#### Identifying when to talk who, about what 
+Both types of support will can be relevant for the same situations; each benefits from specific forms of interacting and recognising form is  most useful in relation to when we ge the other is part of what we're practising. 
 
-#### Tips & Tools for Asking for Support
+* Care support offers a [holding space](https://psychhub.com/resources/articles/holding-space) for to express their feelings and perspectives without judgement or advice
 
-...
-## When Do We Offer Support?
+* Accountability support offers a gentle challenge to reflect on alternative perspectives that help us practice holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-#### Tips & Tools for Offering Care Support
+The following diagram offers an example of the varied and iterative pathways between each of our Supporters this may involve: 
 
-**Tips for holding space for participants to express their feelings and perspectives without judgement or advice.** 
+```mermaid
+graph LR
+A[I feel misunderstand] --> B[I can express my feelings/perspectives to a Care Supporter] -->D
+B --> C[I am willing to hear alternative perspectives from an Accountability Supporter] -->D
+A --> C
+C --> A 
+A--> D[I feel ready to discuss the misunderstanding directly]-->A
+```
+
+#### Metacommunicate that want to Asking for, or Offer, Support:
+Once you know who you want to talk to about what:
+- Contact the person in the relevant Supporter role in relation to you   
+- Offer a brief overview of the scope and goal of your request 
+- Once the goal has been articulated and consented to, and all parties have indicated sufficient capacity, agree on the format of communication and any structured-discussion tools.
+- At an agreed time/place, take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) and check that everyone has the available time, energy, and mental-space to give the conversation the appropriate level of attention. If anyone does not have capacity, set another time to reconvene. 
+
+## When & How to Offer Support
+Your roles as a Conduct Supporter is to offer support on request, and in the context of navigating experiences within the Brassica Collective. 
+
+### Tips & Tools for Offering Care Support
+
+**Holding space for participants to express their feelings and perspectives without judgement or advice.** 
 * Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* 
 * The goal is not to help people feel "better" - it is to create space for people to feel whatever it is they are feeling 
 * Focusing on allowing whatever the feeling are to be expressed 
 * Avoid asking "why", expressing any opinions, alternative perspectives, or advice
 
-**Tips for responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
+**Responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
 * Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  
 * Focus on encouraging expressions of perspective, ask clarification questions with *curiosity*
 
-**Tips for supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement**
-- When someone identifies anothers' actions within the collective as at odds with shared expectations or values, remind them reach out to their Accountability Supporter for additional forms of conduct support to seek additional perspectives  
+**Supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement**
+- When someone identifies actions by someone within the collective as at odds with shared expectations or values, remind them reach out to their Accountability Supporter for additional forms of conduct support to seek additional perspectives  
 
-#### Tips & Tools for Offering Accountability Supporter
+### Tips & Tools for offering Accountability Supporter
 
-**Tips for supporting people to consider alternative perspectives**
+**Supporting people to consider alternative perspectives**
 * Offer “yes, and” perspective on what else might be true with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advice)
 * Use the [ladder of inference framework] to support them to the role of assumptions, observations, conclusions, and actions in their interpretations .  
 * Offer examples of when/how actions aren’t aligning with our collectively agreed expectations.  
 * Provide a practice-partner to role-play different ways of interacting
 * Offer to facilitate a [Perspective-sharing process](https://hackmd.io/@Teq/perspective-sharing-facilitation)
 
-**Tips for having 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.** 
+**Initating 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.** 
   
 **Signs that someone may be ready to hold themselves accountable for the consequences of their actions include:**
 - Recognising and sitting with uncomfortable feelings;
@@ -73,7 +91,6 @@ Typically, both types of support will be relevant to any situation. However, rec
 - Reminding participants to reach out to their Care Supporter for additional forms of conduct support.
 - Offer resources, such as:
     - [How to give a good apology](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
-
 
 **Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.**
 

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -13,7 +13,6 @@ open: true
 
 The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to do when we're asked for each of these specific forms of support. 
 
-
 ## When to Ask & Offer Support?
 Ask for support early and often, and respond to support requests generously. 
 
@@ -35,7 +34,7 @@ While both types of support will be relevant for most situations, recognising wh
 
 * Accountability support offers a gentle challenge to practice reflecting on alternative perspectives and holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-The goal is to support each other to directly navigate generative conflict, cultivating an [empowerment triangle, rather than a drama triangle](https://beckett-mcinroy.com/articles/resolving-conflict/). The following diagram offers one example of the varied and iterative pathways we might seek out each of our Supporters: 
+The goal is to support each other to directly navigate generative conflict. The following diagram offers one example of the varied and iterative pathways we might seek out each of our Supporters: 
 
 ```mermaid
 graph LR
@@ -48,19 +47,12 @@ A--> D[I feel ready to direcly resolve the misunderstanding]-->A
 
 ## Tips and Tools for Asking for Support
 
-Once you know which Supporter you want to talk to about what, contact whoever is in the relevant Supporter role in relation to you and practice:
-1.  Making a clearly scoped request. For example, including a brief overview of the context and specifying a requested format and timeline for support can help Supporters make informed decisions about their capacity for providing the requested support. Example formats: 
+Once you know which Supporter you want to talk to about what, contact whoever is in the relevant Supporter role in relation to you. Try to practice the following steps:
+1.  Make a direct request. Briefly outlining the scope of the request can help Supporters make informed decision about providing the requested support (see Example Requests below). 
 
-> "Hi, thanks for being my care supporter. Can we arrange a 15 min call in the next few days? I'd like to talk through my experience of how a recent Crew meeting was facilitated if possible.
+2. Take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) to check that everyone has capacity to give the conversation the appropriate level of attention prior to starting the discussion. If anyone does not have capacity, set another time to reconvene.
 
->  “Hi, are you available for a 30 min calls this week as my Brassica accountability supporter? I had a tense verbal exchange at a recent Crew meeting. I have talked to my care supporter already and would now like help to think about what I could have done differently in that situation.” 
-
-> "Hi, thanks for the care support earlier. I've talked to my accountability supporter and heard about how my actions may have contributed to the situation I expressed frustration about last we talked. I want to resolve the tensions my actions have contributed to but have lingering feelings of defensiveness. Can we arrange another 10 min call this week for me to express those feelings before I talk to others on the crew?"
-
-2. Choosing an appropriate form of [structured-discussion](https://hackmd.io/@IntentionalRelationships/metacommunication) together (see Tips & Tools below).
-
-3. Taking a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) to check that everyone has capacity to give the conversation the appropriate level of attention prior to starting. If anyone does not have capacity, set another time to reconvene.
-
+3. Confirm the time-container (e.g., 20 mins) and choose an appropriate form of [structured-discussion](https://hackmd.io/@IntentionalRelationships/metacommunication) together (see Tips & Tools below).
 
 ## Tips & Tools for Responding to Care Support Requests
 
@@ -110,6 +102,25 @@ By practising with this structured support system we’re pushing back on defaul
 
 When you feel you can, please reach out to your assigned support person again to talk about the experience (how it went, how it could have gone differently). 
 
+## Example Support Requests
+
+Including a clear scope for your request can help Supporters make informed decision about providing the requested support. The examples below include formats that outline a brief overview of the context and request a specific format and timeline for support.
+
+Also see the [examples shared in Loomio](https://loomio.shedberries.app/d/ow365eOI/examples-of-conduct-support-requests)
+
+Example 1 - Care Support Only 
+> "Hi, thanks for being my care supporter - I'm feeling really sad so few folk attended the workshop I facilitated; do you have 10 min for a call to hold a container and listen to me vent my feelings about that within the next day or so?"
+
+Example 2: - Accountability Support Only
+> "Hey thanks for being my accountability supporter. I've learned that others felt like I spoke over people a lot in the last Assembly. I'd like to learn how to listen more in meetings - do you have time this interval to meet up with me and help me practice active listening?
+
+Example 3 - Care --> Accountability --> Care 
+> "Hi, thanks for being my care supporter. Can we arrange a 15 min call in the next few days? I'd like to talk through my experience of how a recent Crew meeting was facilitated.
+
+>  “Hi, are you available for a 30 min calls this week as my Brassica accountability supporter? I had a tense verbal exchange at a recent Crew meeting. I have talked to my care supporter already and would now like help to think about what I could have done differently in that situation.” 
+
+> "Hey, thanks for the care support earlier. I've talked to my accountability supporter and heard about how my actions may have contributed to the situation I expressed frustration about last we talked. I want to resolve the tensions my actions have contributed to but have lingering feelings of defensiveness. Can we arrange another 10 min call this week for me to express those feelings before I talk to others on the crew?"
+
 ## Further Resources 
 
 > "... I finally, finally, take a deep breath and ask for the care I need most from my friends, and am able to do this because of the collective work done to make accepting that care safe and possible." [Leah Lakshmi Piepzna-Samarasinha](https://amplifybookstore.com/products/the-future-is-disabled-by-leah-lakshmi-piepzna-samarasinha?variant=47864940691735) 
@@ -123,5 +134,6 @@ The following resources focus on approaches to conflict that seek to transform o
 - [Conflict Resolution Trainers Manual](https://www.crnhq.org/cr-trainer-manual/) This manual is a comprehensive guide running for highly successful Conflict Resolution sessions. It offers teaching material, group and individual exercises and handouts for over 50 hours of instruction on the 12 skills of Conflict Resolution. Each chapter starts with clear guidelines for constructing training sessions of different lengths. It is invaluable for a new trainer and will refresh and inspire even the most experienced trainer’s material. 
 - [Community Accountability process](https://callingupjustice.com/fumbling-towards-repair/)
 - [Upstream podcast episode Nov 7 2024 "Prefigurative Politics and Workplace Democracy w/Saio Gradin and Nicole Wires"](https://www.upstreampodcast.org/conversations) 
+- A guide to cultivating [empowerment triangles, rather than drama triangles](https://beckett-mcinroy.com/articles/resolving-conflict/). 
 
 

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -14,7 +14,6 @@ open: true
 The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to offer when we're asked for each of these specific forms of conduct support.
 
 ## When and How to Request Support?
-
 Practising asking for support in low-consequence contexts, can help prepare us for when we need to support each other navigate high-consequence forms of conflict.
 
 Examples of some of the low-consequence contexts we can practice seeking support include: when we experience feelings about how others are participating in the collective; when we learn that the way we're participating in crews is impacts others in ways we did not intend; and when we have a minor disagreement we're unable to resolve directly with another participant.  
@@ -26,7 +25,7 @@ While both types of support will be relevant for most situations, recognising wh
 
 * Accountability support offers a gentle challenge to practice reflecting on alternative perspectives and holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-The following diagram offers an example of the varied and iterative pathways we might seek out each of our Supporters for one instance of feeling misunderstood: 
+Cultivating an [empowerment triangle, rather than a drama triangle](https://beckett-mcinroy.com/articles/resolving-conflict/) the goal is to support each other to directly navigate generative conflict. The following diagram offers an example of the varied and iterative pathways we might seek out each of our Supporters for one instance of feeling misunderstood: 
 
 ```mermaid
 graph LR
@@ -45,7 +44,7 @@ Once you know who you want to talk to about what:
 - At an agreed time/place, take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) and check that everyone has capacity to give the conversation the appropriate level of attention. If anyone does not have capacity, set another time to reconvene.
 
 ## When & How to Offer Support
-Your roles as a Conduct Supporter is to offer support on request, and in the context of navigating experiences within the Brassica Collective. 
+Your core role as a Conduct Supporter is to respond to requests for specific forms of support within the scope of our shared conduct expectations within the Brassica Collective.
 
 ### Tips & Tools for Offering Care Support
 
@@ -54,6 +53,7 @@ Your roles as a Conduct Supporter is to offer support on request, and in the con
 * The goal is not to help people feel "better" - it is to create space for people to feel whatever it is they are feeling 
 * Focusing on allowing whatever the feeling are to be expressed 
 * Avoid asking "why", expressing any opinions, alternative perspectives, or advice
+* See the *peer listening* training
 
 **Responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
 * Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -34,11 +34,11 @@ The following diagram offers an example of the varied and iterative pathways bet
 
 ```mermaid
 graph LR
-A[I feel misunderstand] --> B[I can express my feelings/perspectives to a Care Supporter] -->D
+A[I feel misunderstood] --> B[I can express my feelings/perspectives to a Care Supporter] -->D
 B --> C[I am willing to hear alternative perspectives from an Accountability Supporter] -->D
 A --> C
 C --> A 
-A--> D[I feel ready to discuss the misunderstanding directly]-->A
+A--> D[I feel ready to direcly resolve the misunderstanding]-->A
 ```
 
 #### Metacommunicate that want to Asking for, or Offer, Support:

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -11,20 +11,22 @@ open: true
 
 [**Conduct Supporter roles**](../../agreements/supporter_agreement) are intended to help us distribute the labour of supporting each other to act in alignment with our [Conduct Agreement](../../agreements/conduct_agreement). 
 
-The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to offer when we're asked for each of these specific forms of conduct support. We'll learn more about options we might ask for together over time, as each different supporter learns how to provide the specific supports we each ask for.
+The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to do when we're asked for each of these specific forms of support. 
 
-Our initial processes focus on practising reaching out to ask for forms of support and responding to specific support requests (while outside scope, this may help us learn how to pay attention to when and how to offer specific forms of support as well). 
 
-## When and How to Request Support?
-We are practising asking for support early and often so that we can prepare for when we need to support each other navigate higher consequence forms of conflict. 
+## When to Ask & Offer Support?
+Ask for support early and often, and respond to support requests generously. 
 
-As a guide, we aim to reach out to each of our Supporters at least once an interval. 
-Examples of some of the low-consequence contexts we can practice seeking support include: 
-- when we experience feelings about how others are participating in the collective; 
-- when we learn that the way we're participating impacts others in ways we did not intend; and 
-- when we have a minor disagreement we're unable to resolve directly with another participant. 
- 
-### Identifying when to talk who, about what 
+By practising on small forms of support within the scope of our shared conduct expectations, we hope to build our collective capacity for supporting each to other navigate higher consequence forms of conflict. 
+
+Examples of low-consequence contexts we can practice seeking support include: 
+- When we experience feelings about how others are participating in the collective 
+- When we learn our ways of communicating impact others in ways we did not intend 
+- When we have a minor disagreement we're unable to resolve directly with another participant 
+
+We'll explore more options as we all begin to learn how to respond to specific support requests. For now, we encourage participants to reach out to each of our Supporters at least once an interval. To enable this, Conduct Supporters are expected to be available for up to 1hr of support for each supported participant per interval.
+
+## Identifying who to talk to about what
 Who our Supporters are, and who we are supporting, will be visible on our RADicalise Participation Dashboard.
 
 While both types of support will be relevant for most situations, recognising which form of support is most useful when is part of what we're practising. 
@@ -33,7 +35,7 @@ While both types of support will be relevant for most situations, recognising wh
 
 * Accountability support offers a gentle challenge to practice reflecting on alternative perspectives and holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-The goal is to support each other to directly navigate generative conflict, cultivating an [empowerment triangle, rather than a drama triangle](https://beckett-mcinroy.com/articles/resolving-conflict/). The following diagram offers an example of the varied and iterative pathways we might seek out each of our Supporters for one instance of feeling misunderstood: 
+The goal is to support each other to directly navigate generative conflict, cultivating an [empowerment triangle, rather than a drama triangle](https://beckett-mcinroy.com/articles/resolving-conflict/). The following diagram offers one example of the varied and iterative pathways we might seek out each of our Supporters: 
 
 ```mermaid
 graph LR
@@ -44,72 +46,67 @@ C --> A
 A--> D[I feel ready to direcly resolve the misunderstanding]-->A
 ```
 
-### Ask for support:
-We are practising asking for the specific support that we need. 
+## Tips and Tools for Asking for Support
 
-Once you know who you want to talk to about what:
-- Contact whoever is in the relevant Supporter role(s) in relation to you. Make a clearly scoped request, offer a brief overview of the context, and check if they are willing and able to offer support. Example formats: 
+Once you know which Supporter you want to talk to about what, contact whoever is in the relevant Supporter role in relation to you and practice:
+1.  Making a clearly scoped request. For example, including a brief overview of the context and specifying a requested format and timeline for support can help Supporters make informed decisions about their capacity for providing the requested support. Example formats: 
 
-> "Hi, thanks for being my care supporter. If you're available, can we arrange a 30 min call this week for me to talk through my experience of how the last Assembly was facilitated?
+> "Hi, thanks for being my care supporter. Can we arrange a 15 min call in the next few days? I'd like to talk through my experience of how a recent Crew meeting was facilitated if possible.
 
->  “Hi, thanks for being my accountability supporter. Are you available for a 30 min call this week? I had a tense verbal exchange at the Assembly. I have talked to my care supporter already and would now like help to think about what I could have done differently in that situation.” 
+>  “Hi, are you available for a 30 min calls this week as my Brassica accountability supporter? I had a tense verbal exchange at a recent Crew meeting. I have talked to my care supporter already and would now like help to think about what I could have done differently in that situation.” 
 
-- Once the support request has been articulated and consented to, agree on the format of communication (e.g., 30min phone call) and any [structured-discussion tools](https://hackmd.io/@IntentionalRelationships/metacommunication) (e.g., peer-listening).
+> "Hi, thanks for the care support earlier. I've talked to my accountability supporter and heard about how my actions may have contributed to the situation I expressed frustration about last we talked. I want to resolve the tensions my actions have contributed to but have lingering feelings of defensiveness. Can we arrange another 10 min call this week for me to express those feelings before I talk to others on the crew?"
 
-- At an agreed time/place, take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) and check that everyone has capacity to give the conversation the appropriate level of attention. If anyone does not have capacity, set another time to reconvene.
+2. Choosing an appropriate form of [structured-discussion](https://hackmd.io/@IntentionalRelationships/metacommunication) together (see Tips & Tools below).
 
-## When & How to Offer Support
+3. Taking a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) to check that everyone has capacity to give the conversation the appropriate level of attention prior to starting. If anyone does not have capacity, set another time to reconvene.
 
-Your role as a Conduct Supporter is to respond to requests for specific forms of support within the scope of our shared conduct expectations within the Brassica Collective. As a guideline, each interval we try to be available for at least two 30min containers of support requests (plus coordination).
 
-### Tips & Tools for Offering Care Support
+## Tips & Tools for Responding to Care Support Requests
 
-**Holding space for participants to express their feelings and perspectives without judging or rescuing.** 
+**Holding space for participants to express their feelings and perspectives without judgement or advice.** 
 * Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* 
-* The goal is to create space for people to feel whatever it is they are feeling; not to help people feel "better" or solve their concerns.
+* The goal is to create space for people to feel whatever it is they are feeling; not to help people feel "better" , solve their concerns, or otherwise rescue them.
 * Focus on allowing whatever the feeling are to be expressed; avoid asking "why", expressing any opinions, alternative perspectives, or advice
-* Practice using a [*peer listening*](https://loomio.shedberries.app/d/4ZQ5Jg3p/facilitation-notes-from-interval-16-workshop-on-basic-peer-support-skills) container
+* We are practising structuring these discussion using [peer listening containers](https://loomio.shedberries.app/d/4ZQ5Jg3p/facilitation-notes-from-interval-16-workshop-on-basic-peer-support-skills) 
 
 **Responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
-* Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  
-* Focus on encouraging expressions of perspective, ask clarification questions with *curiosity*
-* Encourage different ways of *sharing* their [partial perspectives](https://hackmd.io/@Teq/perspective-sharing-examples)
+* Listen to their perspective of others' behaviours within the collective, holding space for their interpretations and feelings, and asking any clarification questions with *curiosity* 
+* One way to structure this form of support is to focus on encouraging participants to [share their interpretations of a situation, within the context of the participant's partial perspectives](https://hackmd.io/@Teq/perspective-sharing-examples)
 
-**Supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement**
-- When someone identifies actions by someone within the collective as at odds with shared expectations or values, remind them reach out to their Accountability Supporter for additional forms of conduct support to seek additional perspectives  
+**Supporting a participant to initiate the appropriate Response Guidelines from our Conduct Agreement**
+- When someone identifies actions by someone within the collective as at odds with shared expectations or values, remind them to reach out to their Accountability Supporter to to seek additional perspectives and additional forms of conduct support.
 
-### Tips & Tools for offering Accountability Supporter
+## Tips & Tools for offering Accountability Supporter Requests
 
-**Supporting people to consider alternative perspectives**
-* Offer alternative [partial perspectives](https://hackmd.io/@Teq/perspective-sharing-examples) on [what else might be true](http://www.deanspade.net/wp-content/uploads/2025/07/Dean-Spade-EP04-What-Else-Is-True-worksheet.pdf) with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advise). 
-* Use the [ladder of inference framework](https://untools.co/ladder-of-inference/) to support them to consider the role of assumptions, observations, conclusions, and actions in their interpretations .  
+> *“People can support you to be accountable, but no one but you can do the hard work of taking accountability for yourself. Don’t wait until someone else has to bring up your behavior.” - [(Mia Mingus)](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*
 
-**Initiating 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.** 
-
-* Offer examples of when/how actions aren’t aligning with our collectively agreed expectations.  
-* Provide a practice-partner to role-play different ways of interacting
-  
-**Signs that someone may be ready to hold themselves accountable for the consequences of their actions include:**
-- Recognising and sitting with uncomfortable feelings;
-- Identifying when/how actions aligned with values (or not)
-- Acknowledging when and how the relevant actions impacted others
-- Engaging constructively with requests for behavioural changes
-- Willing to commit to specific changes in behaviours and/or expectations moving forward.
-
-> *“People can support you to be accountable, but no one but you can do the hard work of taking accountability for yourself. Don’t wait until someone else has to bring up your behavior.” [(Mia Mingus)](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*
-
-**Tips for supporting people who want to hold themselves accountable for the ways their actions were felt by themselves or others to have contributed to misunderstandings, conflict, and/or harmful situations** 
-- Support engagement in the relevant processes outlined in our other agreements    
-- Reminding participants to reach out to their Care Supporter for additional forms of conduct support.
-- Offer resources, such as:
-    - [How to give a good apology](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
-
-**Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.**
+**Practise courageous conversations**
+* Listen to their interpretation of a situation (avoid forming judgements or offering advise), then use the [ladder of inference framework](https://untools.co/ladder-of-inference/) to support consideration of the role of assumptions, observations, conclusions, and actions in their interpretations .
+* Support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm. For example, consider asking [what else might be true](http://www.deanspade.net/wp-content/uploads/2025/07/Dean-Spade-EP04-What-Else-Is-True-worksheet.pdf) and offering [alternative partial perspectives](https://hackmd.io/@Teq/perspective-sharing-examples). 
 
 
-## Seeking Additional Supports
+**Supporting people who want to hold themselves accountable for the ways their actions were felt by themselves or others to have contributed to misunderstandings, conflict, and/or harmful situations** 
+* Initiate courageous conversations (see above) and remind participants to reach out to their Care Supporter as well.
+* Provide a [sounding-board](https://grammarist.com/idiom/sounding-board/) for them to explore when/how their actions align with our collectively agreed expectations.  
+* Acknowledge signs of readiness to hold themselves accountable for the consequences of their actions. Examples include:
+    - Recognising and sitting with uncomfortable feelings;
+    - Identifying when/how actions aligned with values (or not)
+    - Acknowledging when and how the relevant actions impacted others
+    - Engaging constructively with requests for behavioural changes
+    - Willing to commit to specific changes in behaviours and/or expectations moving forward.
+* Provide a practice-partner to role-play talking directly with others involved in the situation.
+* Support engagement in the relevant processes outlined in our other agreements 
 
-By practising with this structured support system we’re pushing back on defaults. This is difficult, and takes time. In the meantime, our efforts may go badly. In these cases, please ask for support from whomever you would have gone to if we didn’t have assigned support people. 
+**Supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.**
+- Offering reminders to reach out to their Care Supporter for a container to express their feelings and additional forms of conduct support and then return for more Accountability support.
+- Offer containers for courageous conversations (see above)
+- Offer resources, such as [How to give a good apology](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
+
+
+## A Reminder to Cultivate Additional Support Networks
+
+By practising with this structured support system we’re pushing back on defaults. This is difficult, and takes time. In the meantime, our efforts will not always go well. In these cases, please ask for support from whomever you would have gone to if we didn’t have assigned support people. 
 
 When you feel you can, please reach out to your assigned support person again to talk about the experience (how it went, how it could have gone differently). 
 

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -13,41 +13,44 @@ open: true
 
 ***Conduct Supporter*** roles are intended to help us distribute the labour of meeting our shared conduct expectations when resolving misunderstandings, identifying and responding to conflicts, reducing the conditions within which we might harm each other, and practising how we respond to harm when it does occur. 
 
-## FAQs
-
-### Why differentiate between Care Support and Accountability Support?
+**Why differentiate between Care Support and Accountability Support?**
 While supporting someone to hold themselves accountable is a form of care-work (broadly understood), it can be helpful to treat it as different from the care support, above because each requires a different form of interaction. 
 * Care support requires an holding-space forms of support that focus on listening to someone express their perspective and respecting the kinds of support requested (even when these may be different to the kinds of support we think they need or ‘should’ have). See this explanation of the care-work of ['holding space'](https://psychhub.com/resources/articles/holding-space) for people toe express their feelings and perspectives without judgement or advice.
 * Accountability support is about offering  self-reflective and perspective-broadening opportunities; not policing each others' behaviour. This type of support is useful when someone is ready to take responsibility for the consequences of their choices. In this context, the goal is to support each other learn how to hold ourselves accountable for what we said we would do (not to hold others accountable for what they said they would do), including learning about and acknowledging when our behaviour impacting others, and (where relevant)how to change behaviours to reduce potential for harming others. See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-### When do I request Care and/or Accountability?
+## When Do We Request Support?
 
 Practising skills in low consequence conflict can prepare us for if/when we need to collectively navigate more serious instances of violence and/or abuse (i.e., [behaviours …intended to gain, exert, and maintain power over another person or in a group](https://commonslibrary.org/book-review-we-will-not-cancel-us/)).
 
 For example, seeking out accountability support is encouraged whenever gap emerge between what we intend with our actions and the actual impacts on others in the context of particiating in the collective. By inviting feedback from others we can learn the skills of being able to give and receive feedback about how we are doing in relation to our own commitments. With practice, asking for feedback can become a regular part of how we operate together.
 
-Likewise, seekng care support is encouraged whenever feelings emerge in the context of participating in Brassica Collective. Asking for and holding a container to express stong feelings... 
+Likewise, seekng care support is encouraged whenever feelings emerge in the context of participating in Brassica Collective. Asking for and holding a container to express stong feelings offers oppourtunities to practive integrating our experiences and reconnecting with people around us.
 
-## Tips & Tools for Asking for Support
+Typically, both types of support will be relevant to any situation. However, recognising when/why each specific type of support is most relevant is part of what we're hoping to learn through these practices.  
+
+#### Tips & Tools for Asking for Support
 
 ...
+## When Do We Offer Support?
 
-## Tips & Tools for Providing Support
-
-### Providing Care Support
+#### Tips & Tools for Offering Care Support
 
 **Tips for holding space for participants to express their feelings and perspectives without judgement or advice.** 
-* Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* (while avoiding forming judgements or offering advice)..  
+* Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* 
+* The goal is not to help people feel "better" - it is to create space for people to feel whatever it is they are feeling 
+* Focusing on allowing whatever the feeling are to be expressed 
+* Avoid asking "why", expressing any opinions, alternative perspectives, or advice
 
 **Tips for responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
 * Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  
+* Focus on encouraging expressions of perspective, ask clarification questions with *curiosity*
 
 **Tips for supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement**
-- When someone has expressed feelings about actions within the collective that are at odds with our shared expectations or values, remind participants to reach out to their Accountability Supporter for additional forms of conduct support.
+- When someone identifies anothers' actions within the collective as at odds with shared expectations or values, remind them reach out to their Accountability Supporter for additional forms of conduct support to seek additional perspectives  
 
-## Providing Accountability Supporter
+#### Tips & Tools for Offering Accountability Supporter
 
-### Tips for supporting people to consider alternative perspectives
+**Tips for supporting people to consider alternative perspectives**
 * Offer “yes, and” perspective on what else might be true with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advice)
 * Use the [ladder of inference framework] to support them to the role of assumptions, observations, conclusions, and actions in their interpretations .  
 * Offer examples of when/how actions aren’t aligning with our collectively agreed expectations.  

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -11,21 +11,29 @@ open: true
 
 [**Conduct Supporter roles**](../../agreements/supporter_agreement) are intended to help us distribute the labour of supporting each other to act in alignment with our [Conduct Agreement](../../agreements/conduct_agreement). 
 
-The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to offer when we're asked for each of these specific forms of conduct support.
+The following guidelines outline our in-progress collection of tips & tools for learning when to ask for care and accountability support, and what to offer when we're asked for each of these specific forms of conduct support. We'll learn more about options we might ask for together over time, as each different supporter learns how to provide the specific supports we each ask for.
+
+Our initial processes focus on practising reaching out to ask for forms of support and responding to specific support requests (while outside scope, this may help us learn how to pay attention to when and how to offer specific forms of support as well). 
 
 ## When and How to Request Support?
-Practising asking for support in low-consequence contexts, can help prepare us for when we need to support each other navigate high-consequence forms of conflict.
+We are practising asking for support early and often so that we can prepare for when we need to support each other navigate higher consequence forms of conflict. 
 
-Examples of some of the low-consequence contexts we can practice seeking support include: when we experience feelings about how others are participating in the collective; when we learn that the way we're participating in crews is impacts others in ways we did not intend; and when we have a minor disagreement we're unable to resolve directly with another participant.  
+As a guide, we aim to reach out to each of our Supporters at least once an interval. 
+Examples of some of the low-consequence contexts we can practice seeking support include: 
+- when we experience feelings about how others are participating in the collective; 
+- when we learn that the way we're participating impacts others in ways we did not intend; and 
+- when we have a minor disagreement we're unable to resolve directly with another participant. 
+ 
+### Identifying when to talk who, about what 
+Who our Supporters are, and who we are supporting, will be visible on our RADicalise Participation Dashboard.
 
-#### Identifying when to talk who, about what 
 While both types of support will be relevant for most situations, recognising which form of support is most useful when is part of what we're practising. 
 
 * Care support offers a [holding space](https://psychhub.com/resources/articles/holding-space) to practice expressing our feelings and reflecting on our experiences  without exposing ourselves to either judgement or rescue.
 
 * Accountability support offers a gentle challenge to practice reflecting on alternative perspectives and holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
-Cultivating an [empowerment triangle, rather than a drama triangle](https://beckett-mcinroy.com/articles/resolving-conflict/) the goal is to support each other to directly navigate generative conflict. The following diagram offers an example of the varied and iterative pathways we might seek out each of our Supporters for one instance of feeling misunderstood: 
+The goal is to support each other to directly navigate generative conflict, cultivating an [empowerment triangle, rather than a drama triangle](https://beckett-mcinroy.com/articles/resolving-conflict/). The following diagram offers an example of the varied and iterative pathways we might seek out each of our Supporters for one instance of feeling misunderstood: 
 
 ```mermaid
 graph LR
@@ -36,15 +44,23 @@ C --> A
 A--> D[I feel ready to direcly resolve the misunderstanding]-->A
 ```
 
-#### Ask for support:
+### Ask for support:
+We are practising asking for the specific support that we need. 
+
 Once you know who you want to talk to about what:
-- Contact whoever is in the relevant Supporter role(s) in relation to you  
-- Offer a brief overview of the scope of your request and check if they are willing and able to offer support. 
-- Once the support request has been articulated and consented to, agree on the format of communication and any [structured-discussion tools](https://hackmd.io/@IntentionalRelationships/metacommunication).
+- Contact whoever is in the relevant Supporter role(s) in relation to you. Make a clearly scoped request, offer a brief overview of the context, and check if they are willing and able to offer support. Example formats: 
+
+> "Hi, thanks for being my care supporter. If you're available, can we arrange a 30 min call this week for me to talk through my experience of how the last Assembly was facilitated?
+
+>  “Hi, thanks for being my accountability supporter. Are you available for a 30 min call this week? I had a tense verbal exchange at the Assembly. I have talked to my care supporter already and would now like help to think about what I could have done differently in that situation.” 
+
+- Once the support request has been articulated and consented to, agree on the format of communication (e.g., 30min phone call) and any [structured-discussion tools](https://hackmd.io/@IntentionalRelationships/metacommunication) (e.g., peer-listening).
+
 - At an agreed time/place, take a moment to [HALT+](https://www.multiamory.com/podcast/218-ive-halted-now-what) and check that everyone has capacity to give the conversation the appropriate level of attention. If anyone does not have capacity, set another time to reconvene.
 
 ## When & How to Offer Support
-Your core role as a Conduct Supporter is to respond to requests for specific forms of support within the scope of our shared conduct expectations within the Brassica Collective.
+
+Your role as a Conduct Supporter is to respond to requests for specific forms of support within the scope of our shared conduct expectations within the Brassica Collective. As a guideline, each interval we try to be available for at least two 30min containers of support requests (plus coordination).
 
 ### Tips & Tools for Offering Care Support
 
@@ -90,6 +106,12 @@ Your core role as a Conduct Supporter is to respond to requests for specific for
 
 **Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.**
 
+
+## Seeking Additional Supports
+
+By practising with this structured support system we’re pushing back on defaults. This is difficult, and takes time. In the meantime, our efforts may go badly. In these cases, please ask for support from whomever you would have gone to if we didn’t have assigned support people. 
+
+When you feel you can, please reach out to your assigned support person again to talk about the experience (how it went, how it could have gone differently). 
 
 ## Further Resources 
 

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -61,12 +61,21 @@ Signs that someone may be ready include demonstrating capacity for:
 - Support engagement in the relevant processes outlined in our other agreements    
 - Reminding participants to reach out to their Care Supporter for additional forms of conduct support.
 - Offer resources, such as:
-    - [(How to give a good apology)](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
+    - [How to give a good apology](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
 
 
 ### Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.
 
 
-## Further Resources
+## Further Resources 
 
-- [inevitable conflicts](https://commonslibrary.org/conflict-is-inevitable-knowledge-roundup/),
+The following resources focus on approaches to conflict that seek to transform oppressive dynamics, our relationships to each other, and our communities at large. 
+
+- A Commons Library resource roundup on navigating [inevitable conflicts](https://commonslibrary.org/conflict-is-inevitable-knowledge-roundup/),
+- An introduction to [transformative approaches to navigating conflict](https://commonslibrary.org/transformative-approaches-to-conflict-resolution/)
+- [Progressive Therapeutic Collective Radical Repair Toolkit](https://drive.google.com/file/d/13FYQP20FZHr7FSokCQYzRdelmn0eb2A1/view?usp=drive_link) Sarah Newbold© 2025 Underground Radical, Naarm offers a bold approach to relationship repair that challenges power, prioritises equity, and fosters connection in every relationship.
+- [From conflict to co-operation - a Primer](https://peoplesupport.coop/from-conflict-to-cooperation/) - Written by Kate Whittle, Cooperantics, and illustrated by Angela Martin. This From Conflict to Co-operation series aims to help co-operatives not only to deal with conflict when it arises but also to avoid unnecessary conflict.
+- [Conflict Resolution Trainers Manual](https://www.crnhq.org/cr-trainer-manual/) This manual is a comprehensive guide running for highly successful Conflict Resolution sessions. It offers teaching material, group and individual exercises and handouts for over 50 hours of instruction on the 12 skills of Conflict Resolution. Each chapter starts with clear guidelines for constructing training sessions of different lengths. It is invaluable for a new trainer and will refresh and inspire even the most experienced trainer’s material. 
+- [Community Accountability process](https://callingupjustice.com/fumbling-towards-repair/)
+
+

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -21,7 +21,7 @@ Examples of some of the low-consequence contexts we can practice seeking support
 #### Identifying when to talk who, about what 
 While both types of support will be relevant for most situations, recognising which form of support is most useful when is part of what we're practising. 
 
-* Care support offers a [holding space](https://psychhub.com/resources/articles/holding-space) to practice expressing our feelings and reflecting on our experiences  without exposing ourselves to judgement or advice.
+* Care support offers a [holding space](https://psychhub.com/resources/articles/holding-space) to practice expressing our feelings and reflecting on our experiences  without exposing ourselves to either judgement or rescue.
 
 * Accountability support offers a gentle challenge to practice reflecting on alternative perspectives and holding *ourselves* accountable for how our actions impact others (without policing each others' behaviour). See this video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)
 
@@ -48,16 +48,16 @@ Your core role as a Conduct Supporter is to respond to requests for specific for
 
 ### Tips & Tools for Offering Care Support
 
-**Holding space for participants to express their feelings and perspectives without judgement or advice.** 
+**Holding space for participants to express their feelings and perspectives without judging or rescuing.** 
 * Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* 
-* The goal is not to help people feel "better" - it is to create space for people to feel whatever it is they are feeling 
-* Focusing on allowing whatever the feeling are to be expressed 
-* Avoid asking "why", expressing any opinions, alternative perspectives, or advice
-* See the *peer listening* training
+* The goal is to create space for people to feel whatever it is they are feeling; not to help people feel "better" or solve their concerns.
+* Focus on allowing whatever the feeling are to be expressed; avoid asking "why", expressing any opinions, alternative perspectives, or advice
+* Practice using a [*peer listening*](https://loomio.shedberries.app/d/4ZQ5Jg3p/facilitation-notes-from-interval-16-workshop-on-basic-peer-support-skills) container
 
 **Responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm.** 
 * Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  
 * Focus on encouraging expressions of perspective, ask clarification questions with *curiosity*
+* Encourage different ways of *sharing* their [partial perspectives](https://hackmd.io/@Teq/perspective-sharing-examples)
 
 **Supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement**
 - When someone identifies actions by someone within the collective as at odds with shared expectations or values, remind them reach out to their Accountability Supporter for additional forms of conduct support to seek additional perspectives  
@@ -65,13 +65,13 @@ Your core role as a Conduct Supporter is to respond to requests for specific for
 ### Tips & Tools for offering Accountability Supporter
 
 **Supporting people to consider alternative perspectives**
-* Offer “yes, and” perspective on what else might be true with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advice)
-* Use the [ladder of inference framework] to support them to the role of assumptions, observations, conclusions, and actions in their interpretations .  
+* Offer alternative [partial perspectives](https://hackmd.io/@Teq/perspective-sharing-examples) on [what else might be true](http://www.deanspade.net/wp-content/uploads/2025/07/Dean-Spade-EP04-What-Else-Is-True-worksheet.pdf) with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advise). 
+* Use the [ladder of inference framework](https://untools.co/ladder-of-inference/) to support them to consider the role of assumptions, observations, conclusions, and actions in their interpretations .  
+
+**Initiating 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.** 
+
 * Offer examples of when/how actions aren’t aligning with our collectively agreed expectations.  
 * Provide a practice-partner to role-play different ways of interacting
-* Offer to facilitate a [Perspective-sharing process](https://hackmd.io/@Teq/perspective-sharing-facilitation)
-
-**Initating 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.** 
   
 **Signs that someone may be ready to hold themselves accountable for the consequences of their actions include:**
 - Recognising and sitting with uncomfortable feelings;

--- a/content/brassica/handbook/Howtos/supporter_guidelines.md
+++ b/content/brassica/handbook/Howtos/supporter_guidelines.md
@@ -1,0 +1,72 @@
+---
+title: Guidelines for Conduct Supporters
+slug: guidelines_supporters
+type: docs
+prev: guidelines_buddies
+next: handbook_editing
+weight: 6
+sidebar:
+open: true
+---
+
+## Overview
+
+***Conduct Supporter*** roles are intended to help us distribute the labour of meeting our shared conduct expectations when resolving misunderstandings, identifying and responding to conflicts, reducing the conditions within which we might harm each other, and practising how we respond to harm when it does occur. 
+
+
+### Differentiating between Care Support and Accountability Support
+While supporting someone to hold themselves accountable is a form of care-work (broadly understood), it can be helpful to treat it as different from the care support, above because each requires a different form of interaction. 
+* Care support requires an active-listening form of support that focuses on listening to someone express their perspective and respecting the kinds of support requested (even when these may be different to the kinds of support we think they need or ‘should’ have). 
+* Accountability support requires a perspective-broadening form of support. It focuses on supporting someone to take responsibility for the consequences of their choices, acknowledge when these impact others, and learn to make choices that are more aligned with our conduct expectations and collectively agreed values (and less likely to harm others). 
+
+## Care Support Guidelines
+
+### Tips for holding space for participants to express their feelings and perspectives without judgement or advice. 
+* Create a container where you can be present and actively listen to someone express the feelings associated with a situation offering *tenderness, attentiveness, regard, and consideration* (while avoiding forming judgements or offering advice)..  
+
+### Tips for responding to requests for care following situations in which participants felt misunderstood and/or contributed to others feeling misunderstood; participated in or witnessed a conflict; and/or contributed to or experienced harm. 
+* Supporting a participant to articulate and share their perspective of behaviours within the collective they experience as contributing to misunderstandings, conflict, or harmful situations.  
+
+### Tips for supporting a participant to *initiate* the appropriate ‘Response Guidelines’ from our Conduct Agreement
+- who has expressed feelings about actions within the collective that are at odds with our shared expectations or values.
+- Reminding participants to reach out to their Accountability Supporter for additional forms of conduct support.
+
+### Additional Resources:
+A explanation of how to ['holding space'](https://psychhub.com/resources/articles/holding-space) for participants to express their feelings and perspectives without judgement or advice.  
+
+## Accountability Supporter Guidelines
+
+* A video on [What is Accountability?](https://www.youtube.com/watch?v=QZuJ55iGI14)   
+
+### Tips for supporting people to consider alternative perspectives
+* 
+* Offer “yes, and” perspective on what else might be true with regards to the situation when listening to an interpretation of a situation (avoid forming judgements or offering advice)
+* Use the [ladder of inference framework] to support them to the role of assumptions, observations, conclusions, and actions in their interpretations .  
+* Offer examples of when/how actions aren’t aligning with our collectively agreed expectations.  
+* Provide a practice-partner to role-play different ways of interacting
+
+### Tips for having 'courageous conversations' that support people to engage with multiple perspectives on how their actions in the collective may have contributed to a particular situation of misunderstanding, conflict, or harm.  
+  
+### Tips for identify if/when someone is ready to hold themselves accountable for the consequences of their actions
+Signs that someone may be ready include demonstrating capacity for:
+- Recognising and sitting with uncomfortable feelings;
+- Identifying when/how actions aligned with values (or not)
+- Acknowledging when and how the relevant actions impacted others
+- Engaging constructively with requests for behavioural changes
+- Willing to commit to specific changes in behaviours and/or expectations moving forward.
+
+> *“People can support you to be accountable, but no one but you can do the hard work of taking accountability for yourself. Don’t wait until someone else has to bring up your behavior.” [(Mia Mingus)](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*
+
+### Tips for supporting people who want to hold themselves accountable for the ways their actions were felt by themselves or others to have contributed to misunderstandings, conflict, and/or harmful situations. 
+- Support engagement in the relevant processes outlined in our other agreements    
+- Reminding participants to reach out to their Care Supporter for additional forms of conduct support.
+- Offer resources, such as:
+    - [(How to give a good apology)](https://leavingevidence.wordpress.com/2019/12/18/how-to-give-a-good-apology-part-1-the-four-parts-of-accountability/)*   
+
+
+### Tips for supporting a participant to *engage with a Conduct Agreement response* after learning that they have acted in ways that feel to another participant as at odds with the shared expectations outlined in our Conduct Agreement.
+
+
+## Further Resources
+
+- [inevitable conflicts](https://commonslibrary.org/conflict-is-inevitable-knowledge-roundup/),


### PR DESCRIPTION
This is intended as a first-pass set of resources that participants can use to help them ask for support, and Conduct Supporters can use to practice responding to distinct forms of support requests. 

I expect to edit/update it within the next few intervals as people offer feedback. Assuming no glaring errors, I'd like to get it in the handbook as a starting point.